### PR TITLE
Updated Data Source in ProductDataContext

### DIFF
--- a/Products/appsettings.json
+++ b/Products/appsettings.json
@@ -7,6 +7,6 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "ProductsContext": "Data Source=Database.db"
+    "ProductsContext": "Data Source=/home/app/Database.db"
   }
 }


### PR DESCRIPTION
Fixes SQLite Error 14: 'unable to open database file'.